### PR TITLE
優化 jcrop.js & map toggling 載入錯誤

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     jwt (1.5.6)
-    kaminari (0.16.3)
+    kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     launchy (2.4.3)
@@ -334,4 +334,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.3

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,5 +24,7 @@
 
 
 $(document).ready(function() {
+  if ($(".events.crop").length > 0) {
     document.jcrop.init({ file_input_id: 'event_photo' });
+  }
 });

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -55,16 +55,13 @@ handler.buildMap({ provider: {}, internal: {id: 'map'}}, function(){
   handler.fitMapToBounds();
 });
 
-$(document).ready(function(){
-  $("#hide").click(function(){
-      if($(".mapbox").css("display")=="none"){
-        $(".mapbox").slideDown();
-        document.getElementById('hide').value= "<%= I18n.t("hide_map") %>";
-      }else{
-        $(".mapbox").slideUp();
-        document.getElementById('hide').value= "<%= I18n.t("show_map") %>";
-      }
-  });
-
+$(document).on("click", "#hide", function(){
+  if($(".mapbox").css("display")=="none"){
+    $(".mapbox").slideDown();
+    document.getElementById('hide').value= "<%= I18n.t("hide_map") %>";
+  }else{
+    $(".mapbox").slideUp();
+    document.getElementById('hide').value= "<%= I18n.t("show_map") %>";
+  }
 });
 </script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
   <%= csrf_meta_tags %>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
-<body>
+<body class="<%= controller_name %> <%= action_name %>">
 <%= render "common/navbar" %>
 <%= render "common/flash" %>
 <%= yield %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20161011112528) do
 
   create_table "event_photos", force: :cascade do |t|


### PR DESCRIPTION
在 body 加入 controller_name & action for page specific js loading control
將 mapbox toggling 改為 綁定在 document 上，避免重複綁定